### PR TITLE
Fix compiler errors from using MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
+.vs/
 .idea/
 
 bits/
@@ -8,3 +9,4 @@ build/
 graph/
 
 CMakeUserPresets.json
+*.pdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_MODULE_STD ON)
 
+if(MSVC)
+    string(APPEND CMAKE_CXX_FLAGS " /Zc:__cplusplus")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 include(CTest)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 10,
+  "version": 9,
   "cmakeMinimumRequired": {
     "major": 4,
     "minor": 0,

--- a/engine/native/thirdparty/boost/ut.hpp
+++ b/engine/native/thirdparty/boost/ut.hpp
@@ -17,6 +17,7 @@
 #endif
 
 #if defined(_MSC_VER)
+#include <stdlib.h>
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -3077,16 +3078,16 @@ struct suite {
   }
 };
 
-[[maybe_unused]] inline auto log = detail::log{};
-[[maybe_unused]] inline auto that = detail::that_{};
+[[maybe_unused]] auto log = detail::log{};
+[[maybe_unused]] auto that = detail::that_{};
 [[maybe_unused]] constexpr auto test = [](const auto name) {
   return detail::test{"test", name};
 };
 [[maybe_unused]] constexpr auto should = test;
-[[maybe_unused]] inline auto tag = [](const auto name) {
+[[maybe_unused]] auto tag = [](const auto name) {
   return detail::tag{{name}};
 };
-[[maybe_unused]] inline auto skip = tag("skip");
+[[maybe_unused]] auto skip = tag("skip");
 template <class T = void>
 [[maybe_unused]] constexpr auto type = detail::type_<T>();
 


### PR DESCRIPTION
I hope it's okay to use CMakePresets version 9, because otherwise Visual Studio refuses to use it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build system configuration for improved compiler compatibility
  * Enhanced Visual Studio development environment integration
  * Updated project configuration presets
  * Improved testing framework setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->