### PR TITLE
Added quick scalar implementations of distance, distance_sq, lerp, min, max, clamp, and abs to vec4.

### DIFF
--- a/engine/native/core/math/vector4.cppm
+++ b/engine/native/core/math/vector4.cppm
@@ -170,5 +170,54 @@ export namespace draco::math {
         return v / length(v);
     }
 
+    // Returns distance between two vectors.
+    [[nodiscard]] FORCEINLINE float distance(const Vector4& a, const Vector4& b) noexcept {
+        return length(b - a);
+    }
+
+    // Return squared distance between two vectors.
+    [[nodiscard]] FORCEINLINE float distance_sq(const Vector4& a, const Vector4& b) noexcept {
+        return length_sq(a - b);
+    }
+
+    // Linear interpolation, t is weight.
+    [[nodiscard]] FORCEINLINE Vector4 lerp(const Vector4& a, const Vector4& b, float t) noexcept {
+        return a + (b - a) * t;
+    }
+
+    // Returns smallest vector between a and b.
+    [[nodiscard]] constexpr Vector4 min(const Vector4& a, const Vector4& b) noexcept {
+        return {
+            std::min(a.x, b.x),
+            std::min(a.y, b.y),
+            std::min(a.z, b.z),
+            std::min(a.w, b.w)
+        };
+    }
+
+    // Returns largest vector between a and b.
+    [[nodiscard]] constexpr Vector4 max(const Vector4& a, const Vector4& b) noexcept {
+        return {
+            std::max(a.x, b.x),
+            std::max(a.y, b.y),
+            std::max(a.z, b.z),
+            std::max(a.w, b.w)
+        }
+    }
+
+    // Clamps each component of x to the range [x_min, x_max]. Presupposes x_min <= x_max.
+    [[nodiscard]] constexpr Vector4 clamp(const Vector4& x, const Vector4& x_min, const Vector4& x_max) noexcept {
+        return max(x_min, min(x, x_max));
+    }
+
+    // Returns absolute value of each component of v.
+    [[nodiscard]] constexpr Vector4 abs(const Vector4& v) noexcept {
+        return {
+            std::abs(v.x),
+            std::abs(v.y),
+            std::abs(v.z),
+            std::abs(v.w)
+        };
+    }
 
 } // namespace draco::math

--- a/engine/native/core/math/vector4.cppm
+++ b/engine/native/core/math/vector4.cppm
@@ -147,4 +147,28 @@ export namespace draco::math {
             return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w;
         #endif
     }
+
+    // Returns squared magnitude.
+    [[nodiscard]] FORCEINLINE float length_sq(const Vector4& v) noexcept {
+        return dot(v, v);
+    }
+
+    // Returns magnitude
+    [[nodiscard]] FORCEINLINE float length(const Vector4& v) noexcept {
+        return std::sqrt(length_sq(v));
+    }
+
+    // Safe normalize, checks length.
+    [[nodiscard]] FORCEINLINE Vector4 normalize(const Vector4& v) noexcept {
+        const float len = length(v);
+
+        return (len > 0.0f) ? v / len : Vector4{0,0,0,0};
+    }
+
+    // Faster normalize, it presupposes vector has non-zero length.
+    [[nodiscard]] FORCEINLINE Vector4 normalize_fast(const Vector4& v) noexcept {
+        return v / length(v);
+    }
+
+
 } // namespace draco::math


### PR DESCRIPTION
Title.

We will still need to make tests, but these are just generic implementations of them. I will go back over them later, as needed, to improve performance via simd intrinsics and such. But I'll keep these as defaults/scalar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the math library with new Vector4 utilities: distance and distance-squared calculations, linear interpolation, component-wise min/max and absolute value operations, and component-wise clamping. These additions simplify common vector math tasks and make numerical operations more concise and expressive in client code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->