### PR TITLE
Add basic allocators

### DIFF
--- a/engine/native/CMakeLists.txt
+++ b/engine/native/CMakeLists.txt
@@ -4,4 +4,4 @@ include(Modules)
 add_subdirectory(thirdparty SYSTEM)
 
 add_modules_library(core SHARED)
-target_link_libraries(core PUBLIC definitions math)
+target_link_libraries(core PUBLIC definitions math memory)

--- a/engine/native/core/CMakeLists.txt
+++ b/engine/native/core/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_modules_library(definitions PIC)
 add_modules_library(math)
+add_modules_library(memory)
 target_link_libraries(math PUBLIC definitions)

--- a/engine/native/core/core.cppm
+++ b/engine/native/core/core.cppm
@@ -1,3 +1,4 @@
 export module core;
 export import core.defs;
 export import core.math;
+export import core.memory;

--- a/engine/native/core/memory/allocator.cpp
+++ b/engine/native/core/memory/allocator.cpp
@@ -1,0 +1,34 @@
+module;
+
+#include <cstddef>
+
+module core.memory.allocator;
+
+namespace draco::memory
+{
+	Error nilAlloc(
+		Allocator alloc,
+		Slice *dst,
+		size_t size,
+		size_t align
+	)
+	{
+		return Error::NotImplemented;
+	}
+
+	Error nilFree(Allocator alloc, Slice block)
+	{
+		return Error::NotImplemented;
+	}
+
+	Error nilFreeAll(Allocator alloc)
+	{
+		return Error::NotImplemented;
+	}
+
+	void asAllocatorVoid(Allocator *dst, void *alloc, AllocatorVTbl *vtbl)
+	{
+		dst->allocatorData = (void*)alloc;
+		dst->vtbl = vtbl;
+	}
+}

--- a/engine/native/core/memory/allocator.cppm
+++ b/engine/native/core/memory/allocator.cppm
@@ -1,0 +1,67 @@
+module;
+
+#include <cstddef>
+
+export module core.memory.allocator;
+export import core.memory.slice;
+
+export namespace draco::memory
+{
+	enum class Error
+	{
+		Okay,
+		OutOfMemory,
+		NotImplemented,
+		Other, // This one shouldn't be needed. If you see it returned, make a
+			   // new error.
+	};
+
+	struct AllocatorVTbl;
+
+	struct Allocator
+	{
+		AllocatorVTbl *vtbl;
+		void *allocatorData;
+	};
+
+	struct AllocatorVTbl
+	{
+		using AllocFn = Error (*)(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		);
+		using FreeFn = Error (*)(Allocator alloc, Slice block);
+		using FreeAllFn = Error (*)(Allocator alloc);
+		AllocFn alloc;
+		FreeFn free;
+		FreeAllFn freeAll;
+	};
+
+	Error nilAlloc(
+		Allocator alloc,
+		Slice *dst,
+		size_t size,
+		size_t align
+	)
+	{
+		return Error::NotImplemented;
+	}
+
+	Error nilFree(Allocator alloc, Slice block)
+	{
+		return Error::NotImplemented;
+	}
+
+	Error nilFreeAll(Allocator alloc)
+	{
+		return Error::NotImplemented;
+	}
+
+	void asAllocatorVoid(Allocator *dst, void *alloc, AllocatorVTbl *vtbl)
+	{
+		dst->allocatorData = (void*)alloc;
+		dst->vtbl = vtbl;
+	}
+}

--- a/engine/native/core/memory/allocator.cppm
+++ b/engine/native/core/memory/allocator.cppm
@@ -12,6 +12,7 @@ export namespace draco::memory
 		Okay,
 		OutOfMemory,
 		NotImplemented,
+		IllegalAddressRange,
 		Other, // This one shouldn't be needed. If you see it returned, make a
 			   // new error.
 	};

--- a/engine/native/core/memory/allocator.cppm
+++ b/engine/native/core/memory/allocator.cppm
@@ -44,24 +44,11 @@ export namespace draco::memory
 		Slice *dst,
 		size_t size,
 		size_t align
-	)
-	{
-		return Error::NotImplemented;
-	}
+	);
 
-	Error nilFree(Allocator alloc, Slice block)
-	{
-		return Error::NotImplemented;
-	}
+	Error nilFree(Allocator alloc, Slice block);
 
-	Error nilFreeAll(Allocator alloc)
-	{
-		return Error::NotImplemented;
-	}
+	Error nilFreeAll(Allocator alloc);
 
-	void asAllocatorVoid(Allocator *dst, void *alloc, AllocatorVTbl *vtbl)
-	{
-		dst->allocatorData = (void*)alloc;
-		dst->vtbl = vtbl;
-	}
+	void asAllocatorVoid(Allocator *dst, void *alloc, AllocatorVTbl *vtbl);
 }

--- a/engine/native/core/memory/bumpAllocator.cpp
+++ b/engine/native/core/memory/bumpAllocator.cpp
@@ -1,0 +1,117 @@
+module;
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+module core.memory.bumpAllocator;
+
+namespace draco::memory::bump
+{
+	void init(
+		BumpAllocator *alloc,
+		Allocator baseAlloc,
+		// one page by default on unix-like systems
+		size_t minAllocRequest
+	)
+	{
+		memset(alloc, 0, sizeof(BumpAllocator));
+		alloc->base = baseAlloc;
+		alloc->minAllocRequest = minAllocRequest;
+	}
+
+	void deinit(BumpAllocator *alloc)
+	{
+		Node *lastNode;
+		Node *node = alloc->first;
+		while (node != nullptr)
+		{
+			lastNode = node;
+			node = node->next;
+			alloc->base.vtbl->free(
+				alloc->base,
+				{
+					.data = (void*)lastNode,
+					.size = lastNode->size + sizeof(Node),
+			   	}
+			);
+		}
+	}
+
+	Error alloc(Allocator alloc, Slice *dst, size_t size, size_t align)
+	{
+		Error err;
+		BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
+		uintptr_t alignMask = align - 1;
+		Node **lastNode;
+		Node **node = &(allocData->first);
+		size_t pos = allocData->allocated;
+		size_t oldPos = pos;
+		size_t reqSize = size;
+		size_t spillover = 0;
+		Slice newBlock;
+		uintptr_t currentPtr;
+		assert(std::popcount(align) == 1);
+		lastNode = node;
+		while (((*node) != nullptr) & (pos > 0))
+		{
+			oldPos = pos;
+			pos -= std::min((*node)->size, pos);
+			lastNode = node;
+			node = &((*node)->next);
+		}
+		assert(pos == 0); // fraudulent mark provided
+		currentPtr = (uintptr_t)&((*lastNode)->data[oldPos]);
+		reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
+		if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
+		{
+			if (*lastNode)
+			{
+				spillover = ((*lastNode)->size - oldPos);
+			}
+			reqSize = (sizeof(Node) + size + alignMask) & ~alignMask;
+			err = allocData->base.vtbl->alloc(
+				allocData->base,
+				&newBlock,
+				std::max(allocData->minAllocRequest, reqSize),
+				std::max(alignof(Node), align)
+			);
+			if (err != Error::Okay)
+			{
+				return Error::OutOfMemory;
+			}
+			(*node) = (Node *)newBlock.data;
+			(*node)->next = nullptr;
+			(*node)->size = newBlock.size - sizeof(Node);
+			pos = 0;
+			lastNode = node;
+			oldPos = 0;
+		}
+		currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
+		reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
+		currentPtr = (currentPtr + alignMask) & ~alignMask;
+		allocData->allocated += reqSize + spillover;
+		dst->data = (void*)currentPtr;
+		dst->size = size;
+		return Error::Okay;
+	}
+
+	Error freeAll(Allocator alloc)
+	{
+		BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
+		allocData->allocated = 0;
+		return Error::Okay;
+	}
+
+	size_t saveMark(BumpAllocator *self)
+	{
+		return self->allocated;
+	}
+
+	void resumeMark(BumpAllocator *self, size_t mark)
+	{
+		self->allocated = mark;
+	}
+}

--- a/engine/native/core/memory/bumpAllocator.cpp
+++ b/engine/native/core/memory/bumpAllocator.cpp
@@ -63,7 +63,7 @@ namespace draco::memory::bump
 			node = &((*node)->next);
 		}
 		assert(pos == 0); // fraudulent mark provided
-		currentPtr = (uintptr_t)&((*lastNode)->data[oldPos]);
+		currentPtr = (uintptr_t)(oldPos + sizeof(Node));
 		reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
 		if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
 		{

--- a/engine/native/core/memory/bumpAllocator.cpp
+++ b/engine/native/core/memory/bumpAllocator.cpp
@@ -63,7 +63,7 @@ namespace draco::memory::bump
 			node = &((*node)->next);
 		}
 		assert(pos == 0); // fraudulent mark provided
-		currentPtr = (uintptr_t)(oldPos + sizeof(Node));
+		currentPtr = ((uintptr_t)(*lastNode)) + sizeof(Node) + oldPos;
 		reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
 		if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
 		{

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -90,7 +90,7 @@ export namespace draco::memory
 			}
 			assert(pos == 0); // fraudulent mark provided
 			currentPtr = (uintptr_t)&((*lastNode)->data[oldPos]);
-			reqSize += ((reqSize + currentPtr - 1) & alignMask);
+			reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
 			if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
 			{
 				if (*lastNode)

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -109,6 +109,7 @@ export namespace draco::memory
 					return Error::OutOfMemory;
 				}
 				(*node) = (Node *)newBlock.data;
+				(*node)->next = nullptr;
 				(*node)->size = newBlock.size - sizeof(Node);
 				pos = 0;
 				lastNode = node;

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -97,7 +97,7 @@ export namespace draco::memory
 				{
 					spillover = ((*lastNode)->size - oldPos);
 				}
-				reqSize = (sizeof(Node) + size) & ~alignMask;
+				reqSize = (sizeof(Node) + size + alignMask) & ~alignMask;
 				err = allocData->base.vtbl->alloc(
 					allocData->base,
 					&newBlock,

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -1,0 +1,148 @@
+module;
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+export module core.memory.bumpAllocator;
+export import core.memory.allocator;
+export import core.memory.slice;
+
+export namespace draco::memory
+{
+	namespace bump
+	{
+		using namespace std;
+		struct Node;
+
+		struct Node
+		{
+			Node *next;
+			size_t size;
+			uint8_t data[];
+		};
+
+		struct BumpAllocator
+		{
+			Allocator base;
+			Node *first;
+			size_t minAllocRequest;
+			size_t allocated;
+		};
+
+		void init(
+			BumpAllocator *alloc,
+			Allocator baseAlloc,
+			// one page by default on unix-like systems
+			size_t minAllocRequest = (1 << 12)
+		)
+		{
+			memset(alloc, 0, sizeof(BumpAllocator));
+			alloc->base = baseAlloc;
+			alloc->minAllocRequest = minAllocRequest;
+		}
+
+		void deinit(BumpAllocator *alloc)
+		{
+			Node *lastNode;
+			Node *node = alloc->first;
+			while (node != nullptr)
+			{
+				lastNode = node;
+				node = node->next;
+				alloc->base.vtbl->free(
+					alloc->base,
+					{
+						.data = (void*)lastNode,
+						.size = lastNode->size + sizeof(Node),
+				   	}
+				);
+			}
+		}
+
+		Error alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			Error err;
+			BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
+			uintptr_t alignMask = align - 1;
+			Node **lastNode;
+			Node **node = &(allocData->first);
+			size_t pos = allocData->allocated;
+			size_t oldPos = pos;
+			size_t reqSize = size;
+			Slice newBlock;
+			uintptr_t currentPtr;
+			lastNode = node;
+			while (((*node) != nullptr) & (pos > 0))
+			{
+				oldPos = pos;
+				pos -= std::min((*node)->size, pos);
+				lastNode = node;
+				node = &((*node)->next);
+			}
+			assert(pos == 0); // fraudulent mark provided
+			currentPtr = (uintptr_t)&((*lastNode)->data[pos]);
+			reqSize += ((reqSize + currentPtr - 1) & alignMask);
+			if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
+			{
+				reqSize = (sizeof(Node) + size) & ~alignMask;
+				err = allocData->base.vtbl->alloc(
+					allocData->base,
+					&newBlock,
+					std::max(allocData->minAllocRequest, reqSize),
+					std::max(alignof(Node), align)
+				);
+				if (err != Error::Okay)
+				{
+					return Error::OutOfMemory;
+				}
+				(*node) = (Node *)newBlock.data;
+				(*node)->size = newBlock.size - sizeof(Node);
+				pos = 0;
+				lastNode = node;
+			}
+			currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
+			reqSize = (size + ((currentPtr - 1) & alignMask)) & ~alignMask;
+			currentPtr = (currentPtr + alignMask) & ~alignMask;
+			allocData->allocated += reqSize;
+			dst->data = (void*)currentPtr;
+			dst->size = size;
+			return Error::Okay;
+		}
+
+		Error freeAll(Allocator alloc)
+		{
+			BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
+			allocData->allocated = 0;
+			return Error::Okay;
+		}
+
+		AllocatorVTbl bumpAllocatorVtbl = {
+			.alloc = alloc,
+			.free = nilFree,
+			.freeAll = freeAll,
+		};
+
+		size_t saveMark(BumpAllocator *self)
+		{
+			return self->allocated;
+		}
+
+		void resumeMark(BumpAllocator *self, size_t mark)
+		{
+			self->allocated = mark;
+		}
+
+		inline void asAllocator(Allocator *dst, BumpAllocator *alloc)
+		{
+			asAllocatorVoid(dst, (void*)alloc, &bumpAllocatorVtbl);
+		}
+	}
+}

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -79,7 +79,6 @@ export namespace draco::memory
 			size_t spillover = 0;
 			Slice newBlock;
 			uintptr_t currentPtr;
-			assert(std::popcount(align) == 1);
 			lastNode = node;
 			while (((*node) != nullptr) & (pos > 0))
 			{
@@ -116,7 +115,7 @@ export namespace draco::memory
 				oldPos = 0;
 			}
 			currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
-			reqSize = (size + ((currentPtr - 1) & alignMask)) & ~alignMask;
+			reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
 			currentPtr = (currentPtr + alignMask) & ~alignMask;
 			allocData->allocated += reqSize + spillover;
 			dst->data = (void*)currentPtr;

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -13,8 +13,6 @@ export namespace draco::memory
 {
 	namespace bump
 	{
-		struct Node;
-
 		struct Node
 		{
 			Node *next;

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -77,6 +77,7 @@ export namespace draco::memory
 			size_t pos = allocData->allocated;
 			size_t oldPos = pos;
 			size_t reqSize = size;
+			size_t spillover = 0;
 			Slice newBlock;
 			uintptr_t currentPtr;
 			lastNode = node;
@@ -92,6 +93,10 @@ export namespace draco::memory
 			reqSize += ((reqSize + currentPtr - 1) & alignMask);
 			if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
 			{
+				if (*lastNode)
+				{
+					spillover = ((*lastNode)->size - oldPos);
+				}
 				reqSize = (sizeof(Node) + size) & ~alignMask;
 				err = allocData->base.vtbl->alloc(
 					allocData->base,
@@ -111,7 +116,7 @@ export namespace draco::memory
 			currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
 			reqSize = (size + ((currentPtr - 1) & alignMask)) & ~alignMask;
 			currentPtr = (currentPtr + alignMask) & ~alignMask;
-			allocData->allocated += reqSize;
+			allocData->allocated += reqSize + spillover;
 			dst->data = (void*)currentPtr;
 			dst->size = size;
 			return Error::Okay;

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -1,6 +1,5 @@
 module;
 
-#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -36,100 +35,13 @@ export namespace draco::memory
 			Allocator baseAlloc,
 			// one page by default on unix-like systems
 			size_t minAllocRequest = (1 << 12)
-		)
-		{
-			memset(alloc, 0, sizeof(BumpAllocator));
-			alloc->base = baseAlloc;
-			alloc->minAllocRequest = minAllocRequest;
-		}
+		);
 
-		void deinit(BumpAllocator *alloc)
-		{
-			Node *lastNode;
-			Node *node = alloc->first;
-			while (node != nullptr)
-			{
-				lastNode = node;
-				node = node->next;
-				alloc->base.vtbl->free(
-					alloc->base,
-					{
-						.data = (void*)lastNode,
-						.size = lastNode->size + sizeof(Node),
-				   	}
-				);
-			}
-		}
+		void deinit(BumpAllocator *alloc);
 
-		Error alloc(
-			Allocator alloc,
-			Slice *dst,
-			size_t size,
-			size_t align
-		)
-		{
-			Error err;
-			BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
-			uintptr_t alignMask = align - 1;
-			Node **lastNode;
-			Node **node = &(allocData->first);
-			size_t pos = allocData->allocated;
-			size_t oldPos = pos;
-			size_t reqSize = size;
-			size_t spillover = 0;
-			Slice newBlock;
-			uintptr_t currentPtr;
-			assert(std::popcount(align) == 1);
-			lastNode = node;
-			while (((*node) != nullptr) & (pos > 0))
-			{
-				oldPos = pos;
-				pos -= std::min((*node)->size, pos);
-				lastNode = node;
-				node = &((*node)->next);
-			}
-			assert(pos == 0); // fraudulent mark provided
-			currentPtr = (uintptr_t)&((*lastNode)->data[oldPos]);
-			reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
-			if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
-			{
-				if (*lastNode)
-				{
-					spillover = ((*lastNode)->size - oldPos);
-				}
-				reqSize = (sizeof(Node) + size + alignMask) & ~alignMask;
-				err = allocData->base.vtbl->alloc(
-					allocData->base,
-					&newBlock,
-					std::max(allocData->minAllocRequest, reqSize),
-					std::max(alignof(Node), align)
-				);
-				if (err != Error::Okay)
-				{
-					return Error::OutOfMemory;
-				}
-				(*node) = (Node *)newBlock.data;
-				(*node)->next = nullptr;
-				(*node)->size = newBlock.size - sizeof(Node);
-				pos = 0;
-				lastNode = node;
-				oldPos = 0;
-			}
-			currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
-			reqSize = size + ((align - (currentPtr & alignMask)) & alignMask);
-			currentPtr = (currentPtr + alignMask) & ~alignMask;
-			allocData->allocated += reqSize + spillover;
-			dst->data = (void*)currentPtr;
-			dst->size = size;
-			return Error::Okay;
-		}
+		Error alloc(Allocator alloc, Slice *dst, size_t size, size_t align);
 
-		Error freeAll(Allocator alloc)
-		{
-			BumpAllocator *allocData = (BumpAllocator *)alloc.allocatorData;
-			allocData->allocated = 0;
-			return Error::Okay;
-		}
+		Error freeAll(Allocator alloc);
 
 		AllocatorVTbl bumpAllocatorVtbl = {
 			.alloc = alloc,
@@ -137,15 +49,9 @@ export namespace draco::memory
 			.freeAll = freeAll,
 		};
 
-		size_t saveMark(BumpAllocator *self)
-		{
-			return self->allocated;
-		}
+		size_t saveMark(BumpAllocator *self);
 
-		void resumeMark(BumpAllocator *self, size_t mark)
-		{
-			self->allocated = mark;
-		}
+		void resumeMark(BumpAllocator *self, size_t mark);
 
 		inline void asAllocator(Allocator *dst, BumpAllocator *alloc)
 		{

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -79,6 +79,7 @@ export namespace draco::memory
 			size_t spillover = 0;
 			Slice newBlock;
 			uintptr_t currentPtr;
+			assert(std::popcount(align) == 1);
 			lastNode = node;
 			while (((*node) != nullptr) & (pos > 0))
 			{

--- a/engine/native/core/memory/bumpAllocator.cppm
+++ b/engine/native/core/memory/bumpAllocator.cppm
@@ -14,7 +14,6 @@ export namespace draco::memory
 {
 	namespace bump
 	{
-		using namespace std;
 		struct Node;
 
 		struct Node
@@ -80,6 +79,7 @@ export namespace draco::memory
 			size_t spillover = 0;
 			Slice newBlock;
 			uintptr_t currentPtr;
+			assert(std::popcount(align) == 1);
 			lastNode = node;
 			while (((*node) != nullptr) & (pos > 0))
 			{
@@ -89,7 +89,7 @@ export namespace draco::memory
 				node = &((*node)->next);
 			}
 			assert(pos == 0); // fraudulent mark provided
-			currentPtr = (uintptr_t)&((*lastNode)->data[pos]);
+			currentPtr = (uintptr_t)&((*lastNode)->data[oldPos]);
 			reqSize += ((reqSize + currentPtr - 1) & alignMask);
 			if (!(*lastNode) || (reqSize > ((*lastNode)->size - oldPos)))
 			{
@@ -112,6 +112,7 @@ export namespace draco::memory
 				(*node)->size = newBlock.size - sizeof(Node);
 				pos = 0;
 				lastNode = node;
+				oldPos = 0;
 			}
 			currentPtr = ((uintptr_t)&((*lastNode)->data[oldPos]));
 			reqSize = (size + ((currentPtr - 1) & alignMask)) & ~alignMask;

--- a/engine/native/core/memory/bumpAllocator.test.cpp
+++ b/engine/native/core/memory/bumpAllocator.test.cpp
@@ -1,0 +1,101 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+import core.memory;
+
+TEST_CASE("Bump allocator provides distinct pointers on allocation")
+{
+	using namespace draco::memory;
+	bump::BumpAllocator bumpAlloc;
+	Allocator alloc;
+	Slice a;
+	Slice b;
+	Error err;
+	bump::init(&bumpAlloc, page::pageAllocator);
+	bump::asAllocator(&alloc, &bumpAlloc);
+	err = alloc.vtbl->alloc(alloc, &a, sizeof(int), alignof(int));
+	REQUIRE(err == Error::Okay);
+	REQUIRE(bumpAlloc.first != nullptr);
+	// REQUIRE(bumpAlloc.first->next == nullptr);
+	REQUIRE(bumpAlloc.first->size > bumpAlloc.allocated);
+	err = alloc.vtbl->alloc(alloc, &b, sizeof(int), alignof(int));
+	REQUIRE(err == Error::Okay);
+	REQUIRE((((ptrdiff_t)b.data) - ((ptrdiff_t)a.data)) >= sizeof(int));
+	bump::deinit(&bumpAlloc);
+}
+
+TEST_CASE("Bump allocator aligns pointers correctly")
+{
+	using namespace draco::memory;
+	bump::BumpAllocator bumpAlloc;
+	Allocator alloc;
+	Slice a;
+	Slice b;
+	Error err;
+	bump::init(&bumpAlloc, page::pageAllocator);
+	bump::asAllocator(&alloc, &bumpAlloc);
+	err = alloc.vtbl->alloc(alloc, &a, sizeof(uint8_t), 2);
+	REQUIRE(err == Error::Okay);
+	REQUIRE(bumpAlloc.first != nullptr);
+	// REQUIRE(bumpAlloc.first->next == nullptr);
+	REQUIRE(bumpAlloc.first->size > bumpAlloc.allocated);
+	err = alloc.vtbl->alloc(alloc, &b, sizeof(uint8_t), 3);
+	REQUIRE(err == Error::Okay);
+	REQUIRE((((uintptr_t)a.data) & (2 - 1)) == 0);
+	REQUIRE((((uintptr_t)b.data) & (3 - 1)) == 0);
+	bump::deinit(&bumpAlloc);
+}
+
+TEST_CASE("Bump allocator data is well packed")
+{
+	struct Foo
+	{
+		uint32_t a;
+		uint64_t b;
+	};
+	using namespace draco::memory;
+	bump::BumpAllocator bumpAlloc;
+	Allocator alloc;
+	Slice aSlice;
+	Slice bSlice;
+	uint32_t *a;
+	uint64_t *b;
+	Error err;
+	bump::init(&bumpAlloc, page::pageAllocator);
+	bump::asAllocator(&alloc, &bumpAlloc);
+	err = alloc.vtbl->alloc(alloc, &aSlice, sizeof(uint32_t), alignof(Foo));
+	REQUIRE(err == Error::Okay);
+	REQUIRE(bumpAlloc.first != nullptr);
+	// REQUIRE(bumpAlloc.first->next == nullptr);
+	REQUIRE(bumpAlloc.first->size > bumpAlloc.allocated);
+	err = alloc.vtbl->alloc(alloc, &bSlice, sizeof(uint64_t), alignof(Foo));
+	REQUIRE(err == Error::Okay);
+	a = (uint32_t*)aSlice.data;
+	b = (uint64_t*)bSlice.data;
+	*a = 69;
+	*b = 420;
+	REQUIRE(((Foo*)bumpAlloc.first->data)->a == 69);
+	REQUIRE(((Foo*)bumpAlloc.first->data)->b == 420);
+	bump::deinit(&bumpAlloc);
+}
+
+TEST_CASE("Bump allocator allocates second page when available")
+{
+	using namespace draco::memory;
+	bump::BumpAllocator bumpAlloc;
+	Allocator alloc;
+	Slice aSlice;
+	Slice bSlice;
+	Error err;
+	bump::init(&bumpAlloc, page::pageAllocator);
+	bump::asAllocator(&alloc, &bumpAlloc);
+	err = alloc.vtbl->alloc(alloc, &aSlice, 8192, 1);
+	REQUIRE(err == Error::Okay);
+	err = alloc.vtbl->alloc(alloc, &bSlice, 8192, 1);
+	REQUIRE(err == Error::Okay);
+	REQUIRE(aSlice.data != bSlice.data);
+	REQUIRE(aSlice.size == 8192);
+	REQUIRE(bSlice.size == 8192);
+	REQUIRE(bumpAlloc.first->next != nullptr);
+	bump::deinit(&bumpAlloc);
+}

--- a/engine/native/core/memory/bumpAllocator.test.cpp
+++ b/engine/native/core/memory/bumpAllocator.test.cpp
@@ -99,3 +99,24 @@ TEST_CASE("Bump allocator allocates second page when available")
 	REQUIRE(bumpAlloc.first->next != nullptr);
 	bump::deinit(&bumpAlloc);
 }
+
+TEST_CASE("Exact alignment")
+{
+	using namespace draco::memory;
+	bump::BumpAllocator bumpAlloc;
+	Allocator alloc;
+	Slice aSlice;
+	Slice bSlice;
+	Slice cSlice;
+	Error err;
+	bump::init(&bumpAlloc, page::pageAllocator);
+	bump::asAllocator(&alloc, &bumpAlloc);
+	err = alloc.vtbl->alloc(alloc, &aSlice, 5, 1);
+	REQUIRE(err == Error::Okay);
+	err = alloc.vtbl->alloc(alloc, &bSlice, 8, 8);
+	REQUIRE(err == Error::Okay);
+	err = alloc.vtbl->alloc(alloc, &cSlice, 4, 4);
+	REQUIRE(err == Error::Okay);
+	REQUIRE(bumpAlloc.allocated == 20);
+	bump::deinit(&bumpAlloc);
+}

--- a/engine/native/core/memory/bumpAllocator.test.cpp
+++ b/engine/native/core/memory/bumpAllocator.test.cpp
@@ -79,6 +79,7 @@ TEST_CASE("Bump allocator data is well packed")
 	bump::deinit(&bumpAlloc);
 }
 
+// this test needs improvement as the page size on windows is 64k
 TEST_CASE("Bump allocator allocates second page when available")
 {
 	using namespace draco::memory;

--- a/engine/native/core/memory/bumpAllocator.test.cpp
+++ b/engine/native/core/memory/bumpAllocator.test.cpp
@@ -39,10 +39,10 @@ TEST_CASE("Bump allocator aligns pointers correctly")
 	REQUIRE(bumpAlloc.first != nullptr);
 	// REQUIRE(bumpAlloc.first->next == nullptr);
 	REQUIRE(bumpAlloc.first->size > bumpAlloc.allocated);
-	err = alloc.vtbl->alloc(alloc, &b, sizeof(uint8_t), 3);
+	err = alloc.vtbl->alloc(alloc, &b, sizeof(uint8_t), 4);
 	REQUIRE(err == Error::Okay);
 	REQUIRE((((uintptr_t)a.data) & (2 - 1)) == 0);
-	REQUIRE((((uintptr_t)b.data) & (3 - 1)) == 0);
+	REQUIRE((((uintptr_t)b.data) & (4 - 1)) == 0);
 	bump::deinit(&bumpAlloc);
 }
 

--- a/engine/native/core/memory/bumpAllocator.test.cpp
+++ b/engine/native/core/memory/bumpAllocator.test.cpp
@@ -79,7 +79,6 @@ TEST_CASE("Bump allocator data is well packed")
 	bump::deinit(&bumpAlloc);
 }
 
-// this test needs improvement as the page size on windows is 64k
 TEST_CASE("Bump allocator allocates second page when available")
 {
 	using namespace draco::memory;

--- a/engine/native/core/memory/fixedAllocator.cpp
+++ b/engine/native/core/memory/fixedAllocator.cpp
@@ -1,0 +1,51 @@
+module;
+
+#include <bit>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+module core.memory.fixedAllocator;
+
+namespace draco::memory::fixed
+{
+	void init(FixedAllocator *alloc, Slice block)
+	{
+		alloc->buffer = (uint8_t *)block.data;
+		alloc->size = block.size;
+		alloc->allocated = false;
+	}
+
+	Error alloc(
+		Allocator alloc,
+		Slice *dst,
+		size_t size,
+		size_t align
+	)
+	{
+		FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
+		size_t alignMask = align - 1;
+		size_t alignedSize = allocData->size - (
+			(align - (((uintptr_t)allocData->buffer) & alignMask))
+			& alignMask
+		);
+		assert(std::popcount(align) == 1);
+		if (allocData->allocated | (alignedSize < size))
+		{
+			return Error::OutOfMemory;
+		}
+		dst->data = (void *)(
+			((uintptr_t)&(allocData->buffer[alignMask])) & ~alignMask
+		);
+		dst->size = alignedSize;
+		allocData->allocated = true;
+		return Error::Okay;
+	}
+
+	Error freeAll(Allocator alloc)
+	{
+		FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
+		allocData->allocated = false;
+		return Error::Okay;
+	}
+}

--- a/engine/native/core/memory/fixedAllocator.cppm
+++ b/engine/native/core/memory/fixedAllocator.cppm
@@ -1,6 +1,9 @@
 module;
 
+#include <bit>
+#include <cassert>
 #include <cstddef>
+#include <cstdint>
 
 export module core.memory.fixedAllocator;
 export import core.memory.allocator;
@@ -12,14 +15,14 @@ export namespace draco::memory
 	{
 		struct FixedAllocator
 		{
-			void *buffer;
+			uint8_t *buffer;
 			size_t size;
 			bool allocated;
 		};
 
 		void init(FixedAllocator *alloc, Slice block)
 		{
-			alloc->buffer = block.data;
+			alloc->buffer = (uint8_t *)block.data;
 			alloc->size = block.size;
 			alloc->allocated = false;
 		}
@@ -32,17 +35,22 @@ export namespace draco::memory
 		)
 		{
 			FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
-			if (allocData->allocated)
+			size_t alignMask = align - 1;
+			size_t alignedSize = allocData->size - (
+				(align - (((uintptr_t)allocData->buffer) & alignMask))
+				& alignMask
+			);
+			assert(std::popcount(align) == 1);
+			if (allocData->allocated | (alignedSize < size))
 			{
 				return Error::OutOfMemory;
 			}
-			else
-			{
-				dst->data = allocData->buffer;
-				dst->size = allocData->size;
-				allocData->allocated = true;
-				return Error::Okay;
-			}
+			dst->data = (void *)(
+				((uintptr_t)&(allocData->buffer[alignMask])) & ~alignMask
+			);
+			dst->size = alignedSize;
+			allocData->allocated = true;
+			return Error::Okay;
 		}
 
 		Error freeAll(Allocator alloc)

--- a/engine/native/core/memory/fixedAllocator.cppm
+++ b/engine/native/core/memory/fixedAllocator.cppm
@@ -1,6 +1,5 @@
 module;
 
-#include <bit>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -20,45 +19,11 @@ export namespace draco::memory
 			bool allocated;
 		};
 
-		void init(FixedAllocator *alloc, Slice block)
-		{
-			alloc->buffer = (uint8_t *)block.data;
-			alloc->size = block.size;
-			alloc->allocated = false;
-		}
+		void init(FixedAllocator *alloc, Slice block);
 
-		Error alloc(
-			Allocator alloc,
-			Slice *dst,
-			size_t size,
-			size_t align
-		)
-		{
-			FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
-			size_t alignMask = align - 1;
-			size_t alignedSize = allocData->size - (
-				(align - (((uintptr_t)allocData->buffer) & alignMask))
-				& alignMask
-			);
-			assert(std::popcount(align) == 1);
-			if (allocData->allocated | (alignedSize < size))
-			{
-				return Error::OutOfMemory;
-			}
-			dst->data = (void *)(
-				((uintptr_t)&(allocData->buffer[alignMask])) & ~alignMask
-			);
-			dst->size = alignedSize;
-			allocData->allocated = true;
-			return Error::Okay;
-		}
+		Error alloc(Allocator alloc, Slice *dst, size_t size, size_t align);
 
-		Error freeAll(Allocator alloc)
-		{
-			FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
-			allocData->allocated = false;
-			return Error::Okay;
-		}
+		Error freeAll(Allocator alloc);
 
 		AllocatorVTbl fixedAllocatorVtbl = {
 			.alloc = alloc,

--- a/engine/native/core/memory/fixedAllocator.cppm
+++ b/engine/native/core/memory/fixedAllocator.cppm
@@ -10,7 +10,6 @@ export namespace draco::memory
 {
 	namespace fixed
 	{
-		using namespace std;
 		struct FixedAllocator
 		{
 			void *buffer;

--- a/engine/native/core/memory/fixedAllocator.cppm
+++ b/engine/native/core/memory/fixedAllocator.cppm
@@ -1,0 +1,67 @@
+module;
+
+#include <cstddef>
+
+export module core.memory.fixedAllocator;
+export import core.memory.allocator;
+export import core.memory.slice;
+
+export namespace draco::memory
+{
+	namespace fixed
+	{
+		using namespace std;
+		struct FixedAllocator
+		{
+			void *buffer;
+			size_t size;
+			bool allocated;
+		};
+
+		void init(FixedAllocator *alloc, Slice block)
+		{
+			alloc->buffer = block.data;
+			alloc->size = block.size;
+			alloc->allocated = false;
+		}
+
+		Error alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
+			if (allocData->allocated)
+			{
+				return Error::OutOfMemory;
+			}
+			else
+			{
+				dst->data = allocData->buffer;
+				dst->size = allocData->size;
+				allocData->allocated = true;
+				return Error::Okay;
+			}
+		}
+
+		Error freeAll(Allocator alloc)
+		{
+			FixedAllocator *allocData = (FixedAllocator*)alloc.allocatorData;
+			allocData->allocated = false;
+			return Error::Okay;
+		}
+
+		AllocatorVTbl fixedAllocatorVtbl = {
+			.alloc = alloc,
+			.free = nilFree,
+			.freeAll = freeAll,
+		};
+
+		inline void asAllocator(Allocator *dst, FixedAllocator *alloc)
+		{
+			asAllocatorVoid(dst, (void*)alloc, &fixedAllocatorVtbl);
+		}
+	}
+}

--- a/engine/native/core/memory/fixedAllocator.test.cpp
+++ b/engine/native/core/memory/fixedAllocator.test.cpp
@@ -1,0 +1,17 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest.h>
+
+import core.memory;
+
+TEST_CASE("Fixed allocator is correctly aligned")
+{
+	using namespace draco::memory;
+	alignas(8) uint8_t buffer[1024];
+	fixed::FixedAllocator fixedAlloc;
+	Allocator alloc;
+	Slice block;
+	fixed::init(&fixedAlloc, { .data = buffer, .size = 1024 });
+	fixed::asAllocator(&alloc, &fixedAlloc);
+	alloc.vtbl->alloc(alloc, &block, 512, 16);
+	REQUIRE((((uintptr_t)block.data) & 15) == 0);
+}

--- a/engine/native/core/memory/pageAllocator.cpp
+++ b/engine/native/core/memory/pageAllocator.cpp
@@ -59,11 +59,11 @@ namespace draco::memory::page
 		)
 		{
 			SYSTEM_INFO sysinfo;
-			unsigned long pageSizeSub1;
+			size_t pageSizeSub1;
 			size_t reqSize;
 			void *ptr;
 			GetSystemInfo(&sysinfo);
-			pageSizeSub1 = sysinfo.dwAllocationGranularity - 1;
+			pageSizeSub1 = (size_t)(sysinfo.dwAllocationGranularity - 1);
 			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
 			// if this overflows, the request was never going to fit into
 			// memory to begin with.

--- a/engine/native/core/memory/pageAllocator.cpp
+++ b/engine/native/core/memory/pageAllocator.cpp
@@ -46,8 +46,9 @@ namespace draco::memory::page
 
 		Error free(Allocator alloc, Slice block)
 		{
-			munmap(block.data, block.size);
-			return Error::Okay;
+			return munmap(block.data, block.size) ?
+				Error::IllegalAddressRange :
+				Error::Okay;
 		}
 #endif
 #ifdef _WIN32
@@ -114,8 +115,9 @@ namespace draco::memory::page
 
 		Error free(Allocator alloc, Slice block)
 		{
-			VirtualFree(block.data, 0, MEM_RELEASE);
-			return Error::Okay;
+			return VirtualFree(block.data, 0, MEM_RELEASE) ?
+				Error::Okay :
+				Error::IllegalAddressRange;
 		}
 #endif
 }

--- a/engine/native/core/memory/pageAllocator.cpp
+++ b/engine/native/core/memory/pageAllocator.cpp
@@ -1,0 +1,121 @@
+module;
+
+#include <cstddef>
+#ifdef __unix__
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+#ifdef _WIN32
+#include <memoryapi.h>
+#include <sysinfoapi.h>
+#endif
+
+module core.memory.pageAllocator;
+
+namespace draco::memory::page
+{
+#ifdef __unix__
+		Error alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			int pageSizeSub1 = getpagesize() - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
+			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			void *ptr = mmap(
+				nullptr,
+				reqSize,
+				PROT_READ | PROT_WRITE,
+				MAP_ANONYMOUS | MAP_PRIVATE,
+				-1,
+				0
+			);
+			if (((ptrdiff_t)ptr) == -1)
+			{
+				return Error::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return Error::Okay;
+		}
+
+		Error free(Allocator alloc, Slice block)
+		{
+			munmap(block.data, block.size);
+			return Error::Okay;
+		}
+#endif
+#ifdef _WIN32
+		Error alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			SYSTEM_INFO sysinfo;
+			unsigned long pageSizeSub1;
+			size_t reqSize;
+			void *ptr;
+			GetSystemInfo(&sysinfo);
+			pageSizeSub1 = sysinfo.dwAllocationGranularity - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
+			reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			ptr = VirtualAlloc(
+				nullptr,
+				reqSize,
+				MEM_COMMIT | MEM_RESERVE,
+				PAGE_READWRITE
+			);
+			if (ptr == nullptr)
+			{
+				return AllocatorError::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return AllocatorError::Okay;
+		}
+
+		Error allocLargePages(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			size_t pageSize = GetLargePageMinimum();
+			size_t pageSizeSub1 = (pageSize ? pageSize : (4 * 1024)) - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
+			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			void *ptr;
+			ptr = VirtualAlloc(
+				nullptr,
+				reqSize,
+				MEM_COMMIT | MEM_RESERVE | MEM_LARGE_PAGES,
+				PAGE_READWRITE
+			);
+			if (ptr == nullptr)
+			{
+				return AllocatorError::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return AllocatorError::Okay;
+		}
+
+		Error free(Allocator alloc, Slice block)
+		{
+			VirtualFree(block.data, 0, MEM_RELEASE);
+			return Error::Okay;
+		}
+#endif
+}

--- a/engine/native/core/memory/pageAllocator.cpp
+++ b/engine/native/core/memory/pageAllocator.cpp
@@ -76,11 +76,11 @@ namespace draco::memory::page
 			);
 			if (ptr == nullptr)
 			{
-				return AllocatorError::OutOfMemory;
+				return Error::OutOfMemory;
 			}
 			dst->data = ptr;
 			dst->size = reqSize;
-			return AllocatorError::Okay;
+			return Error::Okay;
 		}
 
 		Error allocLargePages(
@@ -105,11 +105,11 @@ namespace draco::memory::page
 			);
 			if (ptr == nullptr)
 			{
-				return AllocatorError::OutOfMemory;
+				return Error::OutOfMemory;
 			}
 			dst->data = ptr;
 			dst->size = reqSize;
-			return AllocatorError::Okay;
+			return Error::Okay;
 		}
 
 		Error free(Allocator alloc, Slice block)

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -109,7 +109,7 @@ export namespace draco::memory
 
 		Error free(Allocator alloc, Slice block)
 		{
-			VirtualFree(block.data, block.size, MEM_DECOMMIT);
+			VirtualFree(block.data, 0, MEM_RELEASE);
 			return Error::Okay;
 		}
 #endif

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -107,9 +107,10 @@ export namespace draco::memory
 			return AllocatorError::Okay;
 		}
 
-		void free(Allocator alloc, Slice block)
+		Error free(Allocator alloc, Slice block)
 		{
 			VirtualFree(block.data, block.size, MEM_DECOMMIT);
+			return Error::Okay;
 		}
 #endif
 

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -27,6 +27,9 @@ export namespace draco::memory
 		)
 		{
 			int pageSizeSub1 = getpagesize() - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
 			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
 			void *ptr = mmap(
 				nullptr,
@@ -65,6 +68,9 @@ export namespace draco::memory
 			void *ptr;
 			GetSystemInfo(&sysinfo);
 			pageSizeSub1 = sysinfo.dwAllocationGranularity - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
 			reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
 			ptr = VirtualAlloc(
 				nullptr,
@@ -90,6 +96,9 @@ export namespace draco::memory
 		{
 			size_t pageSize = GetLargePageMinimum();
 			size_t pageSizeSub1 = (pageSize ? pageSize : (4 * 1024)) - 1;
+			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
+			// if this overflows, the request was never going to fit into
+			// memory to begin with.
 			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
 			void *ptr;
 			ptr = VirtualAlloc(

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -1,14 +1,6 @@
 module;
 
 #include <cstddef>
-#ifdef __unix__
-#include <sys/mman.h>
-#include <unistd.h>
-#endif
-#ifdef _WIN32
-#include <memoryapi.h>
-#include <sysinfoapi.h>
-#endif
 
 export module core.memory.pageAllocator;
 export import core.memory.allocator;
@@ -18,110 +10,9 @@ export namespace draco::memory
 {
 	namespace page
 	{
-#ifdef __unix__
-		Error alloc(
-			Allocator alloc,
-			Slice *dst,
-			size_t size,
-			size_t align
-		)
-		{
-			int pageSizeSub1 = getpagesize() - 1;
-			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
-			// if this overflows, the request was never going to fit into
-			// memory to begin with.
-			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
-			void *ptr = mmap(
-				nullptr,
-				reqSize,
-				PROT_READ | PROT_WRITE,
-				MAP_ANONYMOUS | MAP_PRIVATE,
-				-1,
-				0
-			);
-			if (((ptrdiff_t)ptr) == -1)
-			{
-				return Error::OutOfMemory;
-			}
-			dst->data = ptr;
-			dst->size = reqSize;
-			return Error::Okay;
-		}
+		Error alloc(Allocator alloc, Slice *dst, size_t size, size_t align);
 
-		Error free(Allocator alloc, Slice block)
-		{
-			munmap(block.data, block.size);
-			return Error::Okay;
-		}
-#endif
-#ifdef _WIN32
-		Error alloc(
-			Allocator alloc,
-			Slice *dst,
-			size_t size,
-			size_t align
-		)
-		{
-			SYSTEM_INFO sysinfo;
-			unsigned long pageSizeSub1;
-			size_t reqSize;
-			void *ptr;
-			GetSystemInfo(&sysinfo);
-			pageSizeSub1 = sysinfo.dwAllocationGranularity - 1;
-			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
-			// if this overflows, the request was never going to fit into
-			// memory to begin with.
-			reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
-			ptr = VirtualAlloc(
-				nullptr,
-				reqSize,
-				MEM_COMMIT | MEM_RESERVE,
-				PAGE_READWRITE
-			);
-			if (ptr == nullptr)
-			{
-				return AllocatorError::OutOfMemory;
-			}
-			dst->data = ptr;
-			dst->size = reqSize;
-			return AllocatorError::Okay;
-		}
-
-		Error allocLargePages(
-			Allocator alloc,
-			Slice *dst,
-			size_t size,
-			size_t align
-		)
-		{
-			size_t pageSize = GetLargePageMinimum();
-			size_t pageSizeSub1 = (pageSize ? pageSize : (4 * 1024)) - 1;
-			// Coderabbit, this is for a 64-bit machine with 48-bit addressing,
-			// if this overflows, the request was never going to fit into
-			// memory to begin with.
-			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
-			void *ptr;
-			ptr = VirtualAlloc(
-				nullptr,
-				reqSize,
-				MEM_COMMIT | MEM_RESERVE | MEM_LARGE_PAGES,
-				PAGE_READWRITE
-			);
-			if (ptr == nullptr)
-			{
-				return AllocatorError::OutOfMemory;
-			}
-			dst->data = ptr;
-			dst->size = reqSize;
-			return AllocatorError::Okay;
-		}
-
-		Error free(Allocator alloc, Slice block)
-		{
-			VirtualFree(block.data, 0, MEM_RELEASE);
-			return Error::Okay;
-		}
-#endif
+		Error free(Allocator alloc, Slice block);
 
 		AllocatorVTbl pageAllocatorVtbl = {
 			.alloc = alloc,

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -1,0 +1,126 @@
+module;
+
+#include <cstddef>
+#ifdef __unix__
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+#ifdef _WIN32
+#include <memoryapi.h>
+#include <sysinfoapi.h>
+#endif
+
+export module core.memory.pageAllocator;
+export import core.memory.allocator;
+export import core.memory.slice;
+
+export namespace draco::memory
+{
+	namespace page
+	{
+		using namespace std;
+#ifdef __unix__
+		Error alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			int pageSizeSub1 = getpagesize() - 1;
+			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			void *ptr = mmap(
+				nullptr,
+				reqSize,
+				PROT_READ | PROT_WRITE,
+				MAP_ANONYMOUS | MAP_PRIVATE,
+				-1,
+				0
+			);
+			if (((ptrdiff_t)ptr) == -1)
+			{
+				return Error::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return Error::Okay;
+		}
+
+		Error free(Allocator alloc, Slice block)
+		{
+			munmap(block.data, block.size);
+			return Error::Okay;
+		}
+#endif
+#ifdef _WIN32
+		AllocatorError alloc(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			SYSTEM_INFO sysinfo;
+			unsigned long pageSizeSub1;
+			size_t reqSize;
+			void *ptr;
+			GetSystemInfo(&sysinfo);
+			pageSizeSub1 = sysinfo.dwAllocationGranularity - 1;
+			reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			ptr = VirtualAlloc(
+				nullptr,
+				reqSize,
+				MEM_COMMIT | MEM_RESERVE,
+				PAGE_READWRITE
+			);
+			if (ptr == nullptr)
+			{
+				return AllocatorError::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return AllocatorError::Okay;
+		}
+
+		AllocatorError allocLargePages(
+			Allocator alloc,
+			Slice *dst,
+			size_t size,
+			size_t align
+		)
+		{
+			size_t pageSizeSub1 = GetLargePageMinimum() - 1;
+			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
+			void *ptr;
+			ptr = VirtualAlloc(
+				nullptr,
+				reqSize,
+				MEM_COMMIT | MEM_RESERVE | MEM_LARGE_PAGES,
+				PAGE_READWRITE
+			);
+			if (ptr == nullptr)
+			{
+				return AllocatorError::OutOfMemory;
+			}
+			dst->data = ptr;
+			dst->size = reqSize;
+			return AllocatorError::Okay;
+		}
+
+		void free(Allocator alloc, Slice block)
+		{
+			VirtualFree(block.data, block.size, MEM_DECOMMIT | MEM_RELEASE);
+		}
+#endif
+
+		AllocatorVTbl pageAllocatorVtbl = {
+			.alloc = alloc,
+			.free = free,
+			.freeAll = nilFreeAll,
+		};
+		Allocator pageAllocator = {
+			.vtbl = &pageAllocatorVtbl,
+			.allocatorData = nullptr,
+		};
+	}
+}

--- a/engine/native/core/memory/pageAllocator.cppm
+++ b/engine/native/core/memory/pageAllocator.cppm
@@ -18,7 +18,6 @@ export namespace draco::memory
 {
 	namespace page
 	{
-		using namespace std;
 #ifdef __unix__
 		Error alloc(
 			Allocator alloc,
@@ -53,7 +52,7 @@ export namespace draco::memory
 		}
 #endif
 #ifdef _WIN32
-		AllocatorError alloc(
+		Error alloc(
 			Allocator alloc,
 			Slice *dst,
 			size_t size,
@@ -82,14 +81,15 @@ export namespace draco::memory
 			return AllocatorError::Okay;
 		}
 
-		AllocatorError allocLargePages(
+		Error allocLargePages(
 			Allocator alloc,
 			Slice *dst,
 			size_t size,
 			size_t align
 		)
 		{
-			size_t pageSizeSub1 = GetLargePageMinimum() - 1;
+			size_t pageSize = GetLargePageMinimum();
+			size_t pageSizeSub1 = (pageSize ? pageSize : (4 * 1024)) - 1;
 			size_t reqSize = (size + (pageSizeSub1)) & (~pageSizeSub1);
 			void *ptr;
 			ptr = VirtualAlloc(
@@ -109,7 +109,7 @@ export namespace draco::memory
 
 		void free(Allocator alloc, Slice block)
 		{
-			VirtualFree(block.data, block.size, MEM_DECOMMIT | MEM_RELEASE);
+			VirtualFree(block.data, block.size, MEM_DECOMMIT);
 		}
 #endif
 

--- a/engine/native/core/memory/root.cppm
+++ b/engine/native/core/memory/root.cppm
@@ -1,0 +1,7 @@
+module;
+
+export module core.memory;
+export import core.memory.allocator;
+export import core.memory.fixedAllocator;
+export import core.memory.pageAllocator;
+export import core.memory.bumpAllocator;

--- a/engine/native/core/memory/slice.cppm
+++ b/engine/native/core/memory/slice.cppm
@@ -1,0 +1,14 @@
+module;
+
+#include <cstddef>
+
+export module core.memory.slice;
+
+export namespace draco::memory
+{
+	struct Slice
+	{
+		void *data;
+		size_t size;
+	};
+}


### PR DESCRIPTION
## New Features

- Zig-like composable allocators
  - Fixed allocator - provides a fixed block of memory. Meant to be the base for another allocator
  - Page allocator - provides memory at the granularity of pages. Meant to be the base for another allocator
  - Bump allocator - meant for more granular allocations.
- Tests
  - Tests for the bump allocator given it is the most complex allocator. I was not immediately confident that I would have this one correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core now exposes a memory subsystem: a generic allocator interface, a Slice type, and three allocation strategies — fixed-size single-use allocator, bump-pointer allocator, and page-backed allocator (platform-aware).
* **Tests**
  * Added bump-pointer exact-alignment test and a unit test validating aligned allocation for the fixed-size allocator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Redot-Engine/DraconicEngine/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->