### PR TITLE
Build for Windows and Linux ARM64 in CI

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -3,14 +3,25 @@ name: 🐧 Linux Builds
 on:
   push:
     branches:
-      - '**'
+      - 'master'
   pull_request:
     branches:
       - '**'
 
 jobs:
   build-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ format('ubuntu-24.04{0}', matrix.arch == 'arm64' && '-arm' || '') }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {
+              arch: x64,
+            }
+          - {
+              arch: arm64,
+            }
 
     steps:
       - name: Checkout Source Code
@@ -18,17 +29,20 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
-
+      
       - name: Set up Clang Compiler
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@v2
         with:
           version: 20
 
       - name: Install System Dependencies
         run: |
-          wget https://github.com/Kitware/CMake/releases/download/v4.3.0/cmake-4.3.0-linux-x86_64.tar.gz
-          tar -xzf cmake-4.3.0-linux-x86_64.tar.gz
-          echo "$(pwd)/cmake-4.3.0-linux-x86_64/bin" >> $GITHUB_PATH
+          REL_ARCH=${{ matrix.arch == 'x64' && 'x86_64' || 'aarch64' }}
+          wget https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-linux-${REL_ARCH}.tar.gz
+          wget https://github.com/Kitware/CMake/releases/download/v4.4.2/cmake-4.4.2-SHA-256.txt
+          grep -F "  cmake-4.4.2-linux-${REL_ARCH}.tar.gz" cmake-4.4.2-SHA-256.txt | sha256sum --check -
+          tar -xzf cmake-4.4.2-linux-${REL_ARCH}.tar.gz
+          echo "$(pwd)/cmake-4.4.2-linux-${REL_ARCH}/bin" >> $GITHUB_PATH
 
           sudo apt-get update
           sudo apt-get install -y \
@@ -69,9 +83,9 @@ jobs:
       - name: Cache Build Artifacts
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-ccache-
+            ${{ runner.os }}-${{ matrix.arch }}-ccache-
           max-size: "500M"
 
       - name: Configure Build System
@@ -92,9 +106,9 @@ jobs:
           ctest --test-dir build/debug --output-on-failure -j$(nproc)
 
       - name: Upload Engine Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: linux_debug
+          name: linux_${{ matrix.arch }}_debug
           path: build/debug/
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -3,14 +3,25 @@ name: 🪟 Windows Builds
 on:
   push:
     branches:
-      - '**'
+      - 'master'
   pull_request:
     branches:
       - '**'
 
 jobs:
   build-windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-2025' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {
+              arch: x64,
+            }
+          - {
+              arch: arm64,
+            }
 
     steps:
       - name: Checkout Source Code
@@ -20,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Clang Compiler
-        uses: egor-tensin/setup-clang@v1
+        uses: egor-tensin/setup-clang@v2
         with:
           version: 20
         
@@ -49,35 +60,38 @@ jobs:
       - name: Cache Build Artifacts
         uses: hendrikmuhs/ccache-action@v1.2.23
         with:
-          key: ${{ runner.os }}-ccache-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-ccache-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
           restore-keys: |
-            ${{ runner.os }}-ccache-
+            ${{ runner.os }}-${{ matrix.arch }}-ccache-
           max-size: "500M"
 
       - name: Configure Build System
         shell: pwsh
         run: |
+          $compilerTarget = "${{ matrix.arch == 'arm64' && 'aarch64-pc-windows-msvc' || 'x86_64-pc-windows-msvc' }}"
           cmake --preset debug `
             -G Ninja `
             -DCMAKE_C_COMPILER=clang `
             -DCMAKE_CXX_COMPILER=clang++ `
+            "-DCMAKE_C_COMPILER_TARGET=$compilerTarget" `
+            "-DCMAKE_CXX_COMPILER_TARGET=$compilerTarget" `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Compile Target Binary
         shell: pwsh
         run: |
-          cmake --build build/debug -j $env:NUMBER_OF_PROCESSORS
+          cmake --build build/debug -j $([Environment]::ProcessorCount)
 
       - name: Run Unit Tests
         shell: pwsh
         run: |
-          ctest --test-dir build/debug --output-on-failure -j $env:NUMBER_OF_PROCESSORS
+          ctest --test-dir build/debug --output-on-failure -j $([Environment]::ProcessorCount)
 
       - name: Upload Engine Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: windows_debug
+          name: windows_${{ matrix.arch }}_debug
           path: build/debug/
           if-no-files-found: error
           retention-days: 7

--- a/Engine/cpp/Runtime/Core/Math/Vector4.cppm
+++ b/Engine/cpp/Runtime/Core/Math/Vector4.cppm
@@ -256,7 +256,10 @@ export namespace draco::math {
 
                 return _mm_cvtss_f32(sum);
             #elif ARCH_ARM64
-                #error "ARM64 NEON support not yet implemented."
+                const float32x4_t va = vld1q_f32(&a.x);
+                const float32x4_t vb = vld1q_f32(&b.x);
+
+                return vaddvq_f32(vmulq_f32(va, vb));
             #endif
         }
 


### PR DESCRIPTION
- Fix the duplicated workflow runs on PRs (pr + branch)
- Bump `egor-tensin/setup-clang` from v1 to v2
- Bump `actions/upload-artifact` from v4 to v7
- Bump CMake used on Linux to v4.4.2 (latest)
- Implement Vector4's dot for ARM64
- Build the project for ARM64 on Linux and Windows native GitHub Action runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 support for Vector4 dot-product calculations, improving compatibility on ARM-based systems.

* **Build & Platform Support**
  * Expanded Linux and Windows builds to support both x64 and ARM64 architectures.
  * Added architecture-specific build artifacts for easier platform selection.
  * Updated build tooling and parallelization to improve build and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->